### PR TITLE
Fixing std::cerr syntax

### DIFF
--- a/cpp/include/cpu_operations.h
+++ b/cpp/include/cpu_operations.h
@@ -56,13 +56,11 @@ class CpuOperations {
     // Returns the resulting matrix that is created by running a logical or
     // operation on the two input matrices
     if ((a.rows() != b.rows()) || (a.cols() != b.cols())) {
-      std::cerr << std::endl << "ERROR: MATRICES ARE NOT THE SAME SIZE!"
-                << std::endl << std::endl;
+      std::cerr << "MATRICES ARE NOT THE SAME SIZE!";
       exit(1);  // Exits the program
     } else if (b.rows() == 0 || b.cols() == 0 || a.rows() == 0
         || a.cols() == 0) {
-      std::cerr << std::endl << "ERROR: EMPTY MATRIX AS ARGUMENT!" << std::endl
-                << std::endl;
+      std::cerr << "EMPTY MATRIX AS ARGUMENT!";
       exit(1);  // Exits the program
     }
     return (a.array() || b.array());
@@ -77,8 +75,7 @@ class CpuOperations {
       }
     }
     if (b.rows() == 0 || b.cols() == 0) {
-      std::cerr << std::endl << "ERROR: EMPTY MATRIX AS ARGUMENT!" << std::endl
-                << std::endl;
+      std::cerr << "EMPTY MATRIX AS ARGUMENT!";
       exit(1);  // Exits the program
     }
     return b;
@@ -87,7 +84,7 @@ class CpuOperations {
     // This function returns the logical AND of two boolean matrices
     // Checks to see that the number of rows and columns are the same
     if ((a.rows() != b.rows()) || (a.cols() != b.cols())) {
-      std::cerr << "/nERROR: MATRICES ARE NOT THE SAME SIZE!/n/n";
+      std::cerr << "MATRICES ARE NOT THE SAME SIZE!";
       exit(1);  // Exits the program
     }
     return (a.array() && b.array());
@@ -99,8 +96,7 @@ class CpuOperations {
   static T Rank(const Matrix<T> &a);
   static T FrobeniusNorm(const Matrix<T> &a) {
     if (a.rows() == 0 || a.cols() == 0) {
-      std::cerr << std::endl << "ERROR: EMPTY MATRIX AS ARGUMENT!"
-      << std::endl << std::endl;
+      std::cerr << "EMPTY MATRIX AS ARGUMENT!";
       exit(-1);  // Exits the program
     } else {
       return a.norm();
@@ -134,8 +130,7 @@ class CpuOperations {
   static Matrix<T> OuterProduct(const Vector<T> &a, const Vector<T> &b) {
     // This function returns the outer product of he two passed in vectors
     if (a.size() == 0 || b.size() == 0) {
-      std::cerr << std::endl << "ERROR: EMPTY VECTOR AS ARGUMENT!" << std::endl
-                << std::endl;
+      std::cerr << "EMPTY VECTOR AS ARGUMENT!";
       exit(1);
     }
     return a * b.transpose();
@@ -145,12 +140,10 @@ class CpuOperations {
     // Returns the resulting vector that is created by running a logical or
     // operation on the two input vectors
     if (a.size() != b.size()) {
-      std::cerr << std::endl << "ERROR: VECTORS ARE NOT THE SAME SIZE!"
-                << std::endl << std::endl;
+      std::cerr << "VECTORS ARE NOT THE SAME SIZE!";
       exit(1);  // Exits the program
     } else if (a.size() == 0 || b.size() == 0) {
-      std::cerr << std::endl << "ERROR: EMPTY VECTOR AS ARGUMENT!" << std::endl
-                << std::endl;
+      std::cerr << "EMPTY VECTOR AS ARGUMENT!";
       exit(1);  // Exits the program
     }
     return (a.array() || b.array());
@@ -163,8 +156,7 @@ class CpuOperations {
       b(i) = !b(i);
     }
     if (a.size() == 0) {
-      std::cerr << std::endl << "ERROR: EMPTY VECTOR AS ARGUMENT!" << std::endl
-                << std::endl;
+      std::cerr << "EMPTY VECTOR AS ARGUMENT!";
       exit(1);  // Exits the program
     }
     return b;


### PR DESCRIPTION
Because std::cerr already outputs "ERROR:" we do not need to write it again, so I fixed this so that it would be uniform throughout cpu_operations.h.
